### PR TITLE
fix: fix build step to exclude all deps from bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2528,15 +2528,6 @@
         }
       }
     },
-    "@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://nexus.vmduk.net/repository/npm-group/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.0.8"
-      }
-    },
     "@rollup/plugin-node-resolve": {
       "version": "11.1.0",
       "resolved": "https://nexus.vmduk.net/repository/npm-group/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.1.0.tgz",
@@ -14249,10 +14240,10 @@
         }
       }
     },
-    "rollup-plugin-peer-deps-external": {
-      "version": "2.2.4",
-      "resolved": "https://nexus.vmduk.net/repository/npm-group/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
-      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
+    "rollup-plugin-exclude-dependencies-from-bundle": {
+      "version": "1.1.17",
+      "resolved": "https://nexus.vmduk.net/repository/npm-group/rollup-plugin-exclude-dependencies-from-bundle/-/rollup-plugin-exclude-dependencies-from-bundle-1.1.17.tgz",
+      "integrity": "sha512-hvD2C2NTOmETcN2/Iws4pRJZ4Z1QiCktV4c4mal2AXz04ZCx4oyMtdFPIZ6tFTGRu3c2Rbn/B0jROjJoM/qI8A==",
       "dev": true
     },
     "rsvp": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "^17.0.0",
-    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@types/jest": "^26.0.20",
     "@types/node": "^12.19.8",
@@ -62,7 +61,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.34.1",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-exclude-dependencies-from-bundle": "^1.1.17",
     "semantic-release": "^17.3.0",
     "typescript": "^4.1.2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,16 +1,11 @@
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
-import json from '@rollup/plugin-json';
-import external from 'rollup-plugin-peer-deps-external';
+import external from 'rollup-plugin-exclude-dependencies-from-bundle';
 import pkg from './package.json';
 
 export default [
   {
-    external: {
-      ...pkg.peerDependencies,
-      ...pkg.dependencies,
-    },
     input: 'src/index.ts',
     output: [
       {
@@ -25,7 +20,6 @@ export default [
       },
     ],
     plugins: [
-      json(),
       external(),
       babel({
         babelHelpers: 'bundled',


### PR DESCRIPTION
Rollup wasn't excluding dependencies from the compiled bundle, which is not what we want